### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/app/src/main/java/eu/chainfire/libsuperuser/Application.java
+++ b/app/src/main/java/eu/chainfire/libsuperuser/Application.java
@@ -25,6 +25,9 @@ import android.widget.Toast;
  * toasts and AsyncTasks you are likely to run into
  */
 public class Application extends android.app.Application {
+
+    private static Handler mApplicationHandler = new Handler();
+
     /**
      * Shows a toast message
      * 
@@ -53,8 +56,6 @@ public class Application extends android.app.Application {
             });
         }
     }
-
-    private static Handler mApplicationHandler = new Handler();
 
     /**
      * Run a runnable in the main application thread

--- a/app/src/main/java/eu/chainfire/libsuperuser/Debug.java
+++ b/app/src/main/java/eu/chainfire/libsuperuser/Debug.java
@@ -29,6 +29,23 @@ public class Debug {
 
     private static boolean debug = com.r3pwn.mirrorenabler.BuildConfig.DEBUG;
 
+    public static final String TAG = "libsuperuser";
+
+    public static final int LOG_GENERAL = 0x0001;
+    public static final int LOG_COMMAND = 0x0002;
+    public static final int LOG_OUTPUT = 0x0004;
+
+    public static final int LOG_NONE = 0x0000;
+    public static final int LOG_ALL = 0xFFFF;
+
+    private static int logTypes = LOG_ALL;
+
+    private static OnLogListener logListener = null;
+
+    // ----- SANITY CHECKS -----
+
+    private static boolean sanityChecks = true;
+
     /**
      * <p>Enable or disable debug mode</p>
      * 
@@ -56,19 +73,6 @@ public class Debug {
     public interface OnLogListener {
         public void onLog(int type, String typeIndicator, String message);
     }
-
-    public static final String TAG = "libsuperuser";
-
-    public static final int LOG_GENERAL = 0x0001;
-    public static final int LOG_COMMAND = 0x0002;
-    public static final int LOG_OUTPUT = 0x0004;
-
-    public static final int LOG_NONE = 0x0000;
-    public static final int LOG_ALL = 0xFFFF;
-
-    private static int logTypes = LOG_ALL;
-
-    private static OnLogListener logListener = null;
 
     /**
      * <p>Log a message (internal)</p>
@@ -189,10 +193,6 @@ public class Debug {
     public static OnLogListener getOnLogListener() {
         return logListener;
     }
-
-    // ----- SANITY CHECKS -----
-
-    private static boolean sanityChecks = true;
 
     /**
      * <p>Enable or disable sanity checks</p>

--- a/app/src/main/java/eu/chainfire/libsuperuser/Shell.java
+++ b/app/src/main/java/eu/chainfire/libsuperuser/Shell.java
@@ -41,6 +41,12 @@ import eu.chainfire.libsuperuser.StreamGobbler.OnLineListener;
  * Class providing functionality to execute commands in a (root) shell
  */
 public class Shell {
+
+    protected static String[] availableTestCommands = new String[] {
+            "echo -BOC-",
+            "id"
+    };
+
     /**
      * <p>
      * Runs commands using the supplied shell, and returns the output, or null
@@ -190,11 +196,6 @@ public class Shell {
         Debug.logCommand(String.format("[%s%%] END", shell.toUpperCase(Locale.ENGLISH)));
         return res;
     }
-
-    protected static String[] availableTestCommands = new String[] {
-            "echo -BOC-",
-            "id"
-    };
 
     /**
      * See if the shell is alive, and if so, check the UID


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat