### PR TITLE
Cleanup - squid:S1118 - Utility classes should not have public constr…

### DIFF
--- a/app/src/main/java/eu/chainfire/libsuperuser/Shell.java
+++ b/app/src/main/java/eu/chainfire/libsuperuser/Shell.java
@@ -232,7 +232,10 @@ public class Shell {
     /**
      * This class provides utility functions to easily execute commands using SH
      */
-    public static class SH {
+    public static final class SH {
+
+        private SH() {}
+
         /**
          * Runs command and return output
          * 
@@ -271,7 +274,10 @@ public class Shell {
      * (root shell), as well as detecting whether or not root is available, and
      * if so which version.
      */
-    public static class SU {
+    public static final class SU {
+
+        private SU() {}
+
         private static Boolean isSELinuxEnforcing = null;
         private static String[] suVersion = new String[] {
                 null, null


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat