### PR TITLE
Cleanup - squid:S1943 - Classes and methods that rely on the default …

### DIFF
--- a/app/src/main/java/eu/chainfire/libsuperuser/StreamGobbler.java
+++ b/app/src/main/java/eu/chainfire/libsuperuser/StreamGobbler.java
@@ -20,6 +20,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -60,7 +61,7 @@ public class StreamGobbler extends Thread {
      */
     public StreamGobbler(String shell, InputStream inputStream, List<String> outputList) {
         this.shell = shell;
-        reader = new BufferedReader(new InputStreamReader(inputStream));
+        reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
         writer = outputList;
     }
 
@@ -77,7 +78,7 @@ public class StreamGobbler extends Thread {
      */
     public StreamGobbler(String shell, InputStream inputStream, OnLineListener onLineListener) {
         this.shell = shell;
-        reader = new BufferedReader(new InputStreamReader(inputStream));
+        reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
         listener = onLineListener;
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat
